### PR TITLE
create Mat2d and Mat2dSpec

### DIFF
--- a/vectory/src/main/scala/Mat2d.scala
+++ b/vectory/src/main/scala/Mat2d.scala
@@ -1,0 +1,79 @@
+package vectory
+
+import vectory.Vec2
+
+import annotation.meta.field
+
+@inline final case class Mat2d(
+  m00: Double, m01: Double, m02: Double,
+  m10: Double, m11: Double, m12: Double
+) {
+  @inline def inverted: Mat2d = {
+    var det = determinant
+    if (det != 0) throw new ArithmeticException("Matrix is not invertible")
+    det = 1/det
+    Mat2d(
+      m11 * det, -m01 * det, (m01 * m12 - m02 * m11) * det,
+      -m10 * det, m00 * det,  (m02 * m10 - m00 * m12) * det
+    )
+  }
+
+  @inline def determinant: Double =
+    m00*m11 - m01*m10
+
+  @inline def + (that: Mat2d): Mat2d =
+    Mat2d(
+      m00 + that.m00, m01 + that.m01, m02 + that.m02,
+      m10 + that.m10, m11 + that.m11, m12 + that.m12
+    )
+
+  @inline def - (m: Mat2d): Mat2d =
+    Mat2d(
+      m00 - m.m00, m01 - m.m01, m02 - m.m02,
+      m10 - m.m10, m11 - m.m11, m12 - m.m12
+    )
+
+  @inline def * (s: Float): Mat2d =
+    Mat2d(
+      m00 * s, m01 * s, m02 * s,
+      m10 * s, m11 * s, m12 * s
+    )
+
+  @inline def * (v: Vec2): Vec2 =
+    Vec2(
+      v.x * m00 + v.y * m01 + m02,
+      v.x * m10 + v.y * m11 + m12
+    )
+
+  @inline def * (that: Mat2d): Mat2d =
+    Mat2d(
+      that.m00 * m00 + that.m10 * m01, that.m01 * m00 + that.m11 * m01, that.m02 * m00 + that.m12 * m01 + m02,
+      that.m00 * m10 + that.m10 * m11, that.m01 * m10 + that.m11 * m11, that.m02 * m10 + that.m12 * m11 + m12
+    )
+}
+
+object Mat2d {
+  @inline def identity: Mat2d =
+    Mat2d(
+      1, 0, 0,
+      0, 1, 0
+    )
+
+  @inline def scale2d(x: Double, y: Double): Mat2d =
+    Mat2d(
+      x, 0, 0,
+      0, y, 0
+    )
+
+  @inline def scale2d(v: Vec2): Mat2d =
+    scale2d(v.x, v.y)
+
+  @inline def rotate2d(angle: Double): Mat2d = {
+    val c = math.cos(angle)
+    val s = math.sin(angle)
+    Mat2d(
+      c, -s, 0,
+      s,  c, 0
+    )
+  }
+}

--- a/vectory/src/test/scala/Mat2dSpec.scala
+++ b/vectory/src/test/scala/Mat2dSpec.scala
@@ -1,0 +1,96 @@
+package vectory
+
+import org.scalatest._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+
+class Mat2dSpec extends AnyFreeSpec with Matchers {
+  "constructor" in {
+    val m = Mat2d(5, 7, 3,
+                  1, 4, 9)
+    m.m00 mustEqual 5
+    m.m01 mustEqual 7
+    m.m02 mustEqual 3
+    m.m10 mustEqual 1
+    m.m11 mustEqual 4
+    m.m12 mustEqual 9
+  }
+  "addition" in {
+    val a = Mat2d(4, 6, 3,
+                  5, 1, 2)
+    val b = Mat2d(6, 2, 1,
+                  4, 5, 3)
+    val c = a + b
+    c mustEqual Mat2d(10, 8, 4,
+                       9, 6, 5)
+  }
+  "subtraction" in {
+    val a = Mat2d(3, 2, 6,
+                  1, 5, 4)
+    val b = Mat2d(4, 1, 2,
+                  5, 3, 6)
+    val c = a - b
+    c mustEqual Mat2d(-1,  1,  4,
+                      -4,  2, -2)
+  }
+  "scalar multiplication" in {
+    val a = Mat2d(5, 6, 1,
+                  4, 2, 3)
+    val c = a * 3
+    c mustEqual Mat2d(15, 18,  3,
+                      12,  6,  9)
+  }
+  "vector multiplication" in {
+    val a = Mat2d(5, 6, 1,
+      4, 2, 3)
+    val b = Vec2(7, 8)
+    val c = a * b
+    c mustEqual Vec2(84, 47)
+  }
+  "multiplication" in {
+    val a = Mat2d(6, 5, 1,
+                  4, 3, 2)
+    val b = Mat2d(2, 4, 5,
+                  3, 1, 6)
+
+    val c = a * b
+    c mustEqual Mat2d(27, 29, 61,
+                      17, 19, 40)
+  }
+  "itentity" in {
+    val m = Mat2d.identity
+    m.m00 mustEqual 1
+    m.m01 mustEqual 0
+    m.m02 mustEqual 0
+    m.m10 mustEqual 0
+    m.m11 mustEqual 1
+    m.m12 mustEqual 0
+  }
+  "scale" in {
+    val m = Mat2d.scale2d(3, 5)
+    m.m00 mustEqual 3
+    m.m01 mustEqual 0
+    m.m02 mustEqual 0
+    m.m10 mustEqual 0
+    m.m11 mustEqual 5
+    m.m12 mustEqual 0
+  }
+  "scale from vec2" in {
+    val m = Mat2d.scale2d(Vec2(3, 5))
+    m.m00 mustEqual 3
+    m.m01 mustEqual 0
+    m.m02 mustEqual 0
+    m.m10 mustEqual 0
+    m.m11 mustEqual 5
+    m.m12 mustEqual 0
+  }
+  "rotate 2d" in {
+    val m = Mat2d.rotate2d(.25)
+    m.m00 mustEqual ( .968d +- .005)
+    m.m01 mustEqual (-.247d +- .005)
+    m.m02 mustEqual 0
+    m.m10 mustEqual ( .247d +- .005)
+    m.m11 mustEqual ( .968d +- .005)
+    m.m12 mustEqual 0
+  }
+}


### PR DESCRIPTION
Adds support for 3x3 Matrices with a fixed `0 0 1` bottom row.  
Useful when rotating, scalaing and transforming stuff in 2d.

I needed this. It belongs here, and not in my own math package.  
So far this only includes a very basic feature set, again, I did not need anything else so far.  
I will create more pull requests as I add more stuff.  

When compared to the other files in this lib, the formatting is a bit more verbose, but it makes reading the matricies easier.  
I also created some basic regression tests. Please let me know if there is anything left to be desired.